### PR TITLE
feat: use logger instead of console.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Node modules
-node_modules
-
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Node modules
+node_modules
+
 # Logs
 logs
 *.log

--- a/main.js
+++ b/main.js
@@ -12,18 +12,19 @@ async function run() {
   const apiSecret =
     core.getInput('TWILIO_API_SECRET') || process.env.TWILIO_API_SECRET;
 
-  console.log('Sending SMS');
+  core.debug('Sending SMS');
   const client = twilio(apiKey, apiSecret, { accountSid: accountSid });
   const { sid } = await client.messages.create({
     from: fromPhoneNumber,
     to: toPhoneNumber,
     body: message,
   });
-  console.log('SMS sent!');
+  core.debug('SMS sent!');
 
   core.setOutput('messageSid', sid);
 }
 
 run().catch(err => {
+  core.error('Failed to send message', err.message)
   core.setFailed(err.message);
 });


### PR DESCRIPTION
This PR relates to Issue #4 
- Replace the use of console.log with core logger
- Add an error log

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
