### PR TITLE
Tests: test function value instead of debug log

### DIFF
--- a/action-sms.test.js
+++ b/action-sms.test.js
@@ -23,20 +23,15 @@ test("Log failures", async () => {
   );
 });
 
-test("Output message sid", async () => {
+test("Returns message sid", async () => {
   const sid = "ID123";
 
   twilio.mockReturnValue({
     messages: {
-      create: () => {
-        return { sid };
-      }
+      create: () => ({ sid })
     }
   });
 
-  await run();
-
-  expect(core.setOutput.mock.calls).toEqual(
-    expect.arrayContaining([["messageSid", sid]])
-  );
+  const { sid: resultSid } = await run();
+  expect(resultSid).toEqual(sid);
 });

--- a/dist/main.js
+++ b/dist/main.js
@@ -2,27 +2,31 @@
 const core = require('@actions/core');
 const twilio = require('twilio');
 async function run() {
-    const fromPhoneNumber = core.getInput('fromPhoneNumber');
-    const toPhoneNumber = core.getInput('toPhoneNumber');
+    const from = core.getInput('fromPhoneNumber');
+    const to = core.getInput('toPhoneNumber');
     const message = core.getInput('message');
     const accountSid = core.getInput('TWILIO_ACCOUNT_SID') || process.env.TWILIO_ACCOUNT_SID;
     const apiKey = core.getInput('TWILIO_API_KEY') || process.env.TWILIO_API_KEY;
     const apiSecret = core.getInput('TWILIO_API_SECRET') || process.env.TWILIO_API_SECRET;
     core.debug('Sending SMS');
-    const client = twilio(apiKey, apiSecret, { accountSid: accountSid });
-    const { sid } = await client.messages.create({
-        from: fromPhoneNumber,
-        to: toPhoneNumber,
+    const client = twilio(apiKey, apiSecret, { accountSid });
+    const resultMessage = await client.messages.create({
+        from,
+        to,
         body: message,
     });
     core.debug('SMS sent!');
-    core.setOutput('messageSid', sid);
+    core.setOutput('messageSid', resultMessage.sid);
+    return resultMessage;
 }
-function execute() {
-    run().catch(err => {
-        core.error('Failed to send message', err.message);
-        core.setFailed(err.message);
-    });
+async function execute() {
+    try {
+        return await run();
+    }
+    catch ({ message }) {
+        core.error('Failed to send message', message);
+        core.setFailed(message);
+    }
 }
 module.exports = execute;
 execute();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "npm run build && jest"
   },
   "repository": {
     "type": "git",

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,21 +14,25 @@ async function run() {
 
   core.debug('Sending SMS');
   const client = twilio(apiKey, apiSecret, { accountSid });
-  const { sid } = await client.messages.create({
+  const resultMessage = await client.messages.create({
     from,
     to,
     body: message,
   });
   core.debug('SMS sent!');
 
-  core.setOutput('messageSid', sid);
+  core.setOutput('messageSid', resultMessage.sid);
+
+  return resultMessage;
 }
 
-function execute() {
-  run().catch(({ message }) => {
+async function execute() {
+  try {
+    return await run();
+  } catch({ message }) {
     core.error('Failed to send message', message);
     core.setFailed(message);
-  });
+  }
 }
 
 module.exports = execute;


### PR DESCRIPTION
+ Homogenization of async syntax

<!-- Describe your Pull Request -->

**Contributing to Twilio**

In this PR I tried to render the testing more resilient by testing the actual return function instead of testing the core/log values.

I also tried to render the async/await syntax more homogeneous.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
